### PR TITLE
Make cvs-tag-plugin compatible with cvs-plugin 2.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,14 @@
 target
 work
+
+# IntelliJ project files 
 *.iml
 *.ipr
 *.iws
+.idea
+
+# eclipse project file
+.settings
+.classpath
+.project
+build

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
       <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>cvs</artifactId>
-          <version>2.7-SNAPSHOT</version>
+          <version>2.7</version>
       </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -95,5 +95,12 @@
             <url>http://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+
+
+    <properties>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 </project>  
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,9 +18,9 @@
 
   <dependencies>
       <dependency>
-          <groupId>org.jvnet.hudson.plugins</groupId>
+          <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>cvs</artifactId>
-          <version>1.3</version>
+          <version>2.7-SNAPSHOT</version>
       </dependency>
   </dependencies>
 
@@ -60,6 +60,10 @@
         <role>developer</role>
       </roles>
       <timezone>-5</timezone>
+    </developer>
+    <developer>
+          <id>mc1arke</id>
+          <name>Michael Clarke</name>
     </developer>
   </developers>
 

--- a/src/main/java/hudson/plugins/cvs_tag/CvsTagPlugin.java
+++ b/src/main/java/hudson/plugins/cvs_tag/CvsTagPlugin.java
@@ -41,6 +41,7 @@ import org.netbeans.lib.cvsclient.connection.AuthenticationException;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Map;
 
@@ -113,8 +114,17 @@ public class CvsTagPlugin {
                 Method performMethod = tagAction.getClass().getMethod("perform", String.class, TaskListener.class);
                 performMethod.invoke(tagName, listener);
                 return true;
-            } catch (ReflectiveOperationException ex) {
+            } catch (InvocationTargetException ex) {
                 logger.println("Could not perform tagging - " + ex.getLocalizedMessage());
+                ex.printStackTrace(logger);
+                return false;
+            } catch (NoSuchMethodException ex) {
+                logger.println("Could not perform tagging - " + ex.getLocalizedMessage());
+                ex.printStackTrace(logger);
+                return false;
+            } catch (IllegalAccessException ex) {
+                logger.println("Could not perform tagging - " + ex.getLocalizedMessage());
+                ex.printStackTrace(logger);
                 return false;
             }
         }

--- a/src/main/java/hudson/plugins/cvs_tag/CvsTagPlugin.java
+++ b/src/main/java/hudson/plugins/cvs_tag/CvsTagPlugin.java
@@ -23,24 +23,26 @@
  */
 package hudson.plugins.cvs_tag;
 
-import java.io.IOException;
-import java.io.PrintStream;
-import java.text.DateFormat;
-import java.util.Locale;
-import java.util.Map;
-import java.util.TimeZone;
-
 import groovy.lang.Binding;
 import groovy.lang.GroovyShell;
-import hudson.FilePath;
-import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
 import hudson.model.Result;
+import hudson.model.TaskListener;
 import hudson.scm.CVSSCM;
-import hudson.util.ArgumentListBuilder;
+import hudson.scm.CvsRevisionState;
+import hudson.scm.cvstagging.CvsTagAction;
+import hudson.scm.cvstagging.CvsTagActionWorker;
+import hudson.scm.cvstagging.LegacyTagAction;
 import org.codehaus.groovy.control.CompilerConfiguration;
+import org.netbeans.lib.cvsclient.command.CommandException;
+import org.netbeans.lib.cvsclient.connection.AuthenticationException;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.lang.reflect.Method;
+import java.util.Map;
 
 
 /**
@@ -55,7 +57,7 @@ public class CvsTagPlugin {
     }
 
 
-    public static boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, String tagName, boolean moveTag) throws IOException, InterruptedException {
+    public static boolean perform(AbstractBuild<?, ?> build, BuildListener listener, String tagName, boolean moveTag) throws IOException, InterruptedException {
         PrintStream logger = listener.getLogger();
 
         if (!Result.SUCCESS.equals(build.getResult())) {
@@ -65,7 +67,6 @@ public class CvsTagPlugin {
         }
 
         AbstractProject rootProject = build.getProject().getRootProject();
-        AbstractBuild<?,?> rootBuild = build.getRootBuild();
 
         if (!(rootProject.getScm() instanceof CVSSCM)) {
             logger.println("CVS Tag plugin does not support tagging for SCM " + rootProject.getScm() + ".");
@@ -79,82 +80,53 @@ public class CvsTagPlugin {
         Map<String, String> env = build.getEnvironment(listener);
         tagName = evalGroovyExpression(env, tagName);
 
-        // -D option for rtag command.
-        // Tag the most recent revision no later than <date> ...
-        DateFormat df = DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL, Locale.US);
-        df.setTimeZone(TimeZone.getTimeZone("UTC"));
-        String date = df.format( rootBuild.getTimestamp().getTime());
 
-        ArgumentListBuilder cmd = new ArgumentListBuilder();
-        cmd.add(scm.getDescriptor().getCvsExeOrDefault(), "-d", scm.getCvsRoot());
+        // attempt to use tag information from CVS V2+
+        CvsRevisionState state = build.getAction(CvsRevisionState.class);
 
-        String branch = scm.getBranch();
-        if ( branch != null)
-        {
-            // cvs -d cvsRoot tag -r branch tagName modules
-            cmd.add("tag");
-            if( moveTag )
-            {
-                cmd.add("-F");
-            }
-            cmd.add("-r",scm.getBranch(), tagName);
-        }
-        else
-        {
-            // cvs -d cvsRoot rtag -D date tagName modules
-            cmd.add("rtag");
-            if( moveTag )
-            {
-                cmd.add("-F");
-            }
-            cmd.add("-D", date, tagName);
-        }
-
-
-        String[] modulesNormalized = scm.getAllModulesNormalized();
-        if( branch == null || scm.isLegacy() || modulesNormalized.length > 1 )
-        {
-            cmd.add(scm.getAllModulesNormalized());
-        }
-
-        logger.println("Executing tag command: " + cmd.toStringWithQuote());
-        FilePath workingDir = rootBuild.getWorkspace();
-        if( branch == null )
-        {
-            workingDir = rootBuild.getWorkspace().createTempDir("jenkins-cvs-tag","");
-        }
-
-        try {
-            int exitCode = launcher.launch().cmds(cmd).envs(env).stdout(logger).pwd(workingDir).join();
-            if (exitCode != 0) {
-                listener.fatalError(DESCRIPTION + " failed. exit code=" + exitCode);
-                build.setResult(Result.UNSTABLE);
-            }
-        } catch (IOException e) {
-            e.printStackTrace(listener.error(e.getMessage()));
-            logger.println("IOException occurred: " + e);
-            return false;
-        } catch (InterruptedException e) {
-            e.printStackTrace(listener.error(e.getMessage()));
-            logger.println("InterruptedException occurred: " + e);
-            return false;
-        } finally {
+        if (state != null) {
             try {
-                if ( !workingDir.equals(rootBuild.getWorkspace()) )
-                {
-                    logger.println("cleaning up " + workingDir);
-                    workingDir.deleteRecursive();
-                }
-            } catch (IOException e) {
+                new CvsTagActionWorker(state, tagName, true, build, new CvsTagAction(build, scm), moveTag).perform(listener);
+            } catch (CommandException e) {
                 e.printStackTrace(listener.error(e.getMessage()));
+                return false;
+            } catch (AuthenticationException e) {
+                e.printStackTrace(listener.error(e.getMessage()));
+                return false;
+            }
+            return true;
+        }
+
+        // attempt to use tag infomration from CVS V2+, created by older versions
+        LegacyTagAction legacyTagAction = build.getAction(LegacyTagAction.class);
+
+        if (legacyTagAction != null) {
+           legacyTagAction.perform(tagName, moveTag, listener);
+            return true;
+        }
+
+        //attempt to use tag information from versions before CVS v2
+        CVSSCM.TagAction tagAction = build.getAction(CVSSCM.TagAction.class);
+
+        if (tagAction != null) {
+            try {
+                Method performMethod = tagAction.getClass().getMethod("perform", String.class, TaskListener.class);
+                performMethod.invoke(tagName, listener);
+                return true;
+            } catch (ReflectiveOperationException ex) {
+                logger.println("Could not perform tagging - " + ex.getLocalizedMessage());
+                return false;
             }
         }
 
-        return true;
+        logger.println("Could not find any tagging information for CVS in this build");
+
+        return false;
+
     }
 
 
-    static String evalGroovyExpression(Map<String, String> env, String expression) {
+    protected static String evalGroovyExpression(Map<String, String> env, String expression) {
         Binding binding = new Binding();
         binding.setVariable("env", env);
         binding.setVariable("sys", System.getProperties());

--- a/src/main/java/hudson/plugins/cvs_tag/CvsTagPlugin.java
+++ b/src/main/java/hudson/plugins/cvs_tag/CvsTagPlugin.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2008-2011, Brendt Lucas, Derek Mahar, Bradley Trimby.
+ * Copyright (c) 2008-2012, Brendt Lucas, Derek Mahar, Bradley Trimby, Michael Clarke.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -127,7 +127,7 @@ public class CvsTagPlugin {
         try {
             int exitCode = launcher.launch().cmds(cmd).envs(env).stdout(logger).pwd(workingDir).join();
             if (exitCode != 0) {
-                listener.fatalError(CvsTagPublisher.DESCRIPTOR.getDisplayName() + " failed. exit code=" + exitCode);
+                listener.fatalError(DESCRIPTION + " failed. exit code=" + exitCode);
                 build.setResult(Result.UNSTABLE);
             }
         } catch (IOException e) {

--- a/src/main/java/hudson/plugins/cvs_tag/CvsTagPublisher.java
+++ b/src/main/java/hudson/plugins/cvs_tag/CvsTagPublisher.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2008-2011, Brendt Lucas, Derek Mahar, Bradley Trimby.
+ * Copyright (c) 2008-2012, Brendt Lucas, Derek Mahar, Bradley Trimby, Michael Clarke.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,6 +39,7 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Recorder;
 import hudson.util.FormValidation;
+import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.codehaus.groovy.control.CompilationFailedException;
@@ -59,36 +60,28 @@ public class CvsTagPublisher extends Recorder {
      */
     private String tagName;
 
-    protected CvsTagPublisher() {
-        super();    //To change body of overridden methods use File | Settings | File Templates.
-    }
-
     /**
      * Move the tag.
      */
     private boolean moveTag;
 
-    @Extension
-    public static final CvsTagDescriptorImpl DESCRIPTOR = new CvsTagDescriptorImpl();
+    @DataBoundConstructor
+    public CvsTagPublisher(String tagName, boolean moveTag) {
+        super();
+        this.tagName = tagName;
+        this.moveTag = moveTag;
+    }
+
 
     /**
      * @return the tag name
      */
     public String getTagName() {
         if (tagName == null || tagName.length() == 0) {
-            return DESCRIPTOR.getDefaultTagName();
+            return getDescriptor().getDefaultTagName();
         }
 
         return tagName;
-    }
-
-    /**
-     * Set the tag name
-     *
-     * @param tagName the tag name
-     */
-    public void setTagName(String tagName) {
-        this.tagName = tagName;
     }
 
     /**
@@ -100,17 +93,14 @@ public class CvsTagPublisher extends Recorder {
         return moveTag;
     }
 
+    /**
+     *
+     * @return whether CVS should move any existing tag with the same name
+     * @deprecated use #isMoveTag()
+     */
+    @Deprecated
     public boolean getMoveTag() {
         return moveTag;
-    }
-
-    /**
-     * Enable or disable whether the tag should be moved (-F)
-     *
-     * @param moveTag true to move the tag, false otherwise.
-     */
-    public void setMoveTag(boolean moveTag) {
-        this.moveTag = moveTag;
     }
 
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
@@ -127,14 +117,15 @@ public class CvsTagPublisher extends Recorder {
     }
 
     @Override
-    public BuildStepDescriptor<Publisher> getDescriptor() {
-        return DESCRIPTOR;
+    public CvsTagDescriptorImpl getDescriptor() {
+        return (CvsTagDescriptorImpl) super.getDescriptor();
     }
 
+    @Extension
     public static final class CvsTagDescriptorImpl extends BuildStepDescriptor<Publisher> {
         private String defaultTagName;
 
-        private CvsTagDescriptorImpl() {
+        public CvsTagDescriptorImpl() {
             super(CvsTagPublisher.class);
             this.defaultTagName = "${env['JOB_NAME']}-${env['BUILD_NUMBER']}-${new java.text.SimpleDateFormat(\"yyyy_MM_dd\").format(new Date())}";
             load();
@@ -143,15 +134,6 @@ public class CvsTagPublisher extends Recorder {
         @Override
         public String getDisplayName() {
             return DESCRIPTION;
-        }
-
-        @Override
-        public Recorder newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-            CvsTagPublisher cvsTagPublisher = new CvsTagPublisher();
-            cvsTagPublisher.setTagName(formData.getString("tagName"));
-            cvsTagPublisher.setMoveTag(formData.getBoolean("moveTag"));
-
-            return cvsTagPublisher;
         }
 
         @Override
@@ -169,10 +151,6 @@ public class CvsTagPublisher extends Recorder {
 
         public String getDefaultTagName() {
             return defaultTagName;
-        }
-
-        public void setDefaultTagName(String defaultTagName) {
-            this.defaultTagName = defaultTagName;
         }
 
         public FormValidation doTagNameCheck(@QueryParameter("value") final String tagName) throws IOException, ServletException {


### PR DESCRIPTION
Add support for using version information from version 2.7 of the CVS plugin. Also fix the oustanding issue for cvs-tag-plugin not being listed in conditional-builstep-plugin.

I'm  not sure if we should be applying this change, or merging the CVS-tag plugin and the CVS plugin, given the dependency the former has on the later
